### PR TITLE
Fixed issue with printing single-line progress bars as multiline in external terminals

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 Filip Liwiński
+Copyright (c) 2020-2024 Filip Liwiński
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Free and open-source library with a simple progress indicator for .NET console p
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=filipliwinski_SimpleConsoleProgress&metric=coverage)](https://sonarcloud.io/dashboard?id=filipliwinski_SimpleConsoleProgress)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=filipliwinski_SimpleConsoleProgress&metric=alert_status)](https://sonarcloud.io/dashboard?id=filipliwinski_SimpleConsoleProgress)
 
-Support for .NET Framework (4.5+), .NET Core and .NET 5.
+Support for .NET Framework (4.5+), .NET Core and .NET.
 
 Download from [NuGet](https://www.nuget.org/packages/SimpleConsoleProgress/).
 
 [![NuGet](https://img.shields.io/nuget/v/SimpleConsoleProgress.svg)](https://www.nuget.org/packages/SimpleConsoleProgress/)
-[![NuGet](https://img.shields.io/nuget/dt/SimpleConsoleProgress.svg)](https://www.nuget.org/packages/SimpleConsoleProgress/) 
+[![NuGet](https://img.shields.io/nuget/dt/SimpleConsoleProgress.svg)](https://www.nuget.org/packages/SimpleConsoleProgress/)
 
 ## How to use
 
@@ -178,7 +178,7 @@ The current percentage is displayed by default in the middle of the progress bar
 
 By default, integer values are displayed. You can increase the accuracy to three decimal places.
 
-##### Accuracy - one decimal place 
+##### Accuracy - one decimal place
 
 <img src="./assets/img/accuracy-1.gif?raw=true"/>
 

--- a/src/SimpleConsoleProgress.Demo/Program.cs
+++ b/src/SimpleConsoleProgress.Demo/Program.cs
@@ -79,7 +79,7 @@ namespace SimpleConsoleProgress.Demo
             }
             Console.WriteLine("Process completed.");
 
-            Console.WriteLine("\nAutohide progress bar (single-line)\n");
+            Console.WriteLine("\nAutohide progress bar (single-line only)\n");
             for (int i = 0; i < total; i++)
             {
                 Task.Delay(delay).Wait();
@@ -87,7 +87,7 @@ namespace SimpleConsoleProgress.Demo
             }
             Console.WriteLine("Process completed.");
 
-            Console.WriteLine("Size: Small\n");
+            Console.WriteLine("\nSize: Small\n");
             for (int i = 0; i < total; i++)
             {
                 Task.Delay(delay).Wait();
@@ -95,7 +95,7 @@ namespace SimpleConsoleProgress.Demo
             }
             Console.WriteLine("Process completed.");
 
-            Console.WriteLine("Size: Medium\n");
+            Console.WriteLine("\nSize: Medium\n");
             for (int i = 0; i < total; i++)
             {
                 Task.Delay(delay).Wait();
@@ -103,7 +103,7 @@ namespace SimpleConsoleProgress.Demo
             }
             Console.WriteLine("Process completed.");
 
-            Console.WriteLine("Size: Big\n");
+            Console.WriteLine("\nSize: Big\n");
             for (int i = 0; i < total; i++)
             {
                 Task.Delay(delay).Wait();
@@ -111,7 +111,7 @@ namespace SimpleConsoleProgress.Demo
             }
             Console.WriteLine("Process completed.");
 
-            Console.WriteLine("Size: Full\n");
+            Console.WriteLine("\nSize: Full\n");
             for (int i = 0; i < total; i++)
             {
                 Task.Delay(delay).Wait();
@@ -168,7 +168,9 @@ namespace SimpleConsoleProgress.Demo
             }
             Console.WriteLine("Process completed.");
 
-            Console.WriteLine("\n\n\n\n");
+            Console.WriteLine("\n\n");
+
+            Console.ReadKey();
         }
     }
 }

--- a/src/SimpleConsoleProgress.Demo/Program.cs
+++ b/src/SimpleConsoleProgress.Demo/Program.cs
@@ -150,7 +150,7 @@ namespace SimpleConsoleProgress.Demo
             }
             Console.WriteLine("Process completed.");
 
-            Console.WriteLine("\n\n");
+            Console.WriteLine("\n\nPress any key to close...");
 
             Console.ReadKey();
         }

--- a/src/SimpleConsoleProgress/ProgressBar.cs
+++ b/src/SimpleConsoleProgress/ProgressBar.cs
@@ -28,13 +28,13 @@ namespace SimpleConsoleProgress
             {
                 Console.CursorVisible = false;
             }
+
+            // Store the value of CursorTop for future reference to prevent wrapping to a new line - #25
             var initialCursorTop = Console.CursorTop;
             Console.SetCursorPosition(0, initialCursorTop);
-            using (System.IO.StreamWriter outputFile = new System.IO.StreamWriter("CursorTop.txt", true))
-            {
-                outputFile.WriteLine($"Before write: {Console.CursorTop}");
-            }
+
             Console.Write(GetProgress(current, total, size, elapsed, character, location, accuracy));
+
             if (current + 1 >= total)
             {
                 if (autoHide)
@@ -45,7 +45,6 @@ namespace SimpleConsoleProgress
                     {
                         Console.Write(" ");
                     }
-                    Console.SetCursorPosition(0, initialCursorTop);
                 }
                 else
                 {
@@ -53,16 +52,15 @@ namespace SimpleConsoleProgress
                 }
                 Console.CursorVisible = true;
             }
+
+            // Set position of cursor based on the initial value - #25
             if (autoHide || current + 1 != total) {
                 Console.SetCursorPosition(0, initialCursorTop);
             }
             else
             {
+                // For the last value move to a new line
                 Console.SetCursorPosition(0, initialCursorTop + 1);
-            }
-            using (System.IO.StreamWriter outputFile = new System.IO.StreamWriter("CursorTop.txt", true))
-            {
-                outputFile.WriteLine($"After write: {Console.CursorTop}");
             }
         }
 
@@ -76,17 +74,13 @@ namespace SimpleConsoleProgress
         /// <param name="location">Specifies the position of the percentage.</param>
         public static void WriteLine(int current, int total, TimeSpan? elapsed = null, char character = '#', PercentLocation location = PercentLocation.Middle, int accuracy = 0, BarSize size = BarSize.Full)
         {
+            // Store the value of CursorTop for future reference to prevent wrapping to a new line - #25
             var initialCursorTop = Console.CursorTop;
-            using (System.IO.StreamWriter outputFile = new System.IO.StreamWriter("CursorTop.txt", true))
-            {
-                outputFile.WriteLine($"Before write: {Console.CursorTop}");
-            }
+
             Console.WriteLine(GetProgress(current, total, size, elapsed, character, location, accuracy));
+
+            // Set position of cursor based on the initial value - #25
             Console.SetCursorPosition(0, initialCursorTop + 1);
-            using (System.IO.StreamWriter outputFile = new System.IO.StreamWriter("CursorTop.txt", true))
-            {
-                outputFile.WriteLine($"After write: {Console.CursorTop}");
-            }
         }
 
         internal static string GetProgress(

--- a/src/SimpleConsoleProgress/ProgressBar.cs
+++ b/src/SimpleConsoleProgress/ProgressBar.cs
@@ -46,25 +46,41 @@ namespace SimpleConsoleProgress
             {
                 Console.CursorVisible = false;
             }
-            Console.SetCursorPosition(0, Console.CursorTop);
+            var initialCursorTop = Console.CursorTop;
+            Console.SetCursorPosition(0, initialCursorTop);
+            using (System.IO.StreamWriter outputFile = new System.IO.StreamWriter("CursorTop.txt", true))
+            {
+                outputFile.WriteLine($"Before write: {Console.CursorTop}");
+            }
             Console.Write(GetProgress(current, total, size, elapsed, character, location, accuracy));
             if (current + 1 >= total)
             {
                 if (autoHide)
                 {
                     // Clear console line
-                    Console.SetCursorPosition(0, Console.CursorTop);
+                    Console.SetCursorPosition(0, initialCursorTop);
                     for (int i = 0; i < Console.WindowWidth; i++)
                     {
                         Console.Write(" ");
                     }
-                    Console.SetCursorPosition(0, Console.CursorTop);
+                    Console.SetCursorPosition(0, initialCursorTop);
                 }
                 else
                 {
                     Console.WriteLine();
                 }
                 Console.CursorVisible = true;
+            }
+            if (autoHide || current + 1 != total) {
+                Console.SetCursorPosition(0, initialCursorTop);
+            }
+            else
+            {
+                Console.SetCursorPosition(0, initialCursorTop + 1);
+            }
+            using (System.IO.StreamWriter outputFile = new System.IO.StreamWriter("CursorTop.txt", true))
+            {
+                outputFile.WriteLine($"After write: {Console.CursorTop}");
             }
         }
 
@@ -78,7 +94,17 @@ namespace SimpleConsoleProgress
         /// <param name="location">Specifies the position of the percentage.</param>
         public static void WriteLine(int current, int total, TimeSpan? elapsed = null, char character = '#', PercentLocation location = PercentLocation.Middle, int accuracy = 0, BarSize size = BarSize.Full)
         {
+            var initialCursorTop = Console.CursorTop;
+            using (System.IO.StreamWriter outputFile = new System.IO.StreamWriter("CursorTop.txt", true))
+            {
+                outputFile.WriteLine($"Before write: {Console.CursorTop}");
+            }
             Console.WriteLine(GetProgress(current, total, size, elapsed, character, location, accuracy));
+            Console.SetCursorPosition(0, initialCursorTop + 1);
+            using (System.IO.StreamWriter outputFile = new System.IO.StreamWriter("CursorTop.txt", true))
+            {
+                outputFile.WriteLine($"After write: {Console.CursorTop}");
+            }
         }
 
         internal static string GetProgress(


### PR DESCRIPTION
An extra line was added at the end of every progress bar printout in external terminals (e.g. cmd). This is a fix of issue #25. 